### PR TITLE
Instantiate the editor with initialMarkdown

### DIFF
--- a/index.js
+++ b/index.js
@@ -346,7 +346,7 @@ exports.install = function (Vue, options) {
       })
 
       this.$on('_content-change-markdown', () => {
-        if (this.mode === 'all') {
+        if (['all', 'editor'].includes(this.mode)) {
           const state = EditorState.create({
             doc: defaultMarkdownParser.parse(this.content.markdown),
             plugins: exampleSetup({schema})


### PR DESCRIPTION
Use initialMarkdown value when either "all" or "editor" is in use. Currently, the value in `initialMarkdown` is only visible to the user if you use `"all"` or `"editor"`.